### PR TITLE
feat: restrict daisyUI theme to dim (dark mode) only

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -6,6 +6,6 @@ module.exports = {
   },
   plugins: [require('daisyui')],
   daisyui: {
-    themes: ["light", "dark", "cupcake"],
+    themes: ["dim"],
   },
 };


### PR DESCRIPTION
Updates the `tailwind.config.cjs` file to configure daisyUI. The `themes` array is modified to only include the `dim` theme, which is a dark theme.

This change fulfills your request to have the application use dark mode exclusively.